### PR TITLE
fix {_nl => ___nl} for mini posix array versions

### DIFF
--- a/posix-arrays-a-mini.sh
+++ b/posix-arrays-a-mini.sh
@@ -85,5 +85,5 @@ wrongargs() {
 
 set -f
 export LC_ALL=C
-___nl='
+_nl='
 '

--- a/posix-arrays-i-mini.sh
+++ b/posix-arrays-i-mini.sh
@@ -81,5 +81,5 @@ wrongargs() { echo "$___me: Error: '$*': wrong number of arguments '$#'." >&2; }
 
 set -f
 export LC_ALL=C
-___nl='
+_nl='
 '


### PR DESCRIPTION
The ___nl variable was mistakenly being referred as _nl.

---

Hello friendy-bits,
thank you for providing this open-source solution for posix-arrays!
I'm working on a project that can benefit from it.

While i was using the mini version, i noticed that `_nl` variable does not exist, but `___nl` does. I imagine this was a relic from an older version.

I found this issue by using the `-u` shell flag. This commit does not allow the use of `-u` yet. I will send another MR for `-u` support.