### PR TITLE
Catch unbound variables mini

### DIFF
--- a/posix-arrays-a-mini.sh
+++ b/posix-arrays-a-mini.sh
@@ -85,5 +85,5 @@ wrongargs() {
 
 set -f
 export LC_ALL=C
-___nl='
+_nl='
 '

--- a/posix-arrays-a-mini.sh
+++ b/posix-arrays-a-mini.sh
@@ -66,7 +66,10 @@ get_a_arr_val() {
 ## Backend functions
 
 _check_vars() {
-	case "$1$2$3" in *[!A-Za-z0-9_]* )
+	___check_vars_1=${1:-}
+	___check_vars_2=${2:-}
+	___check_vars_3=${3:-}
+	case "$___check_vars_1$___check_vars_2$___check_vars_3" in *[!A-Za-z0-9_]* )
 		for _test_seq in "_arr_name|array name" "_out_var|output variable name" "___key|key"; do
 			eval "_var_val=\"\$${_test_seq%%|*}\""; _var_desc="${_test_seq#*|}"
 			case "$_var_val" in *[!A-Za-z0-9_]* ) printf '%s\n' "$___me: Error: invalid $_var_desc '$_var_val'." >&2; esac

--- a/posix-arrays-i-mini.sh
+++ b/posix-arrays-i-mini.sh
@@ -67,7 +67,9 @@ get_i_arr_val() {
 ## Backend functions
 
 _check_vars() {
-	case "$1$2" in *[!A-Za-z0-9_]* )
+	___check_vars_1=${1:-}
+	___check_vars_2=${2:-}
+	case "$___check_vars_1$___check_vars_2" in *[!A-Za-z0-9_]* )
 		for _test_seq in "_arr_name|array name" "_out_var|output variable name"; do
 			eval "_var_val=\"\$${_test_seq%%|*}\""; _var_desc="${_test_seq#*|}"
 			case "$_var_val" in *[!A-Za-z0-9_]* ) printf '%s\n' "$___me: Error: invalid $_var_desc '$_var_val'." >&2; esac

--- a/posix-arrays-i-mini.sh
+++ b/posix-arrays-i-mini.sh
@@ -81,5 +81,5 @@ wrongargs() { echo "$___me: Error: '$*': wrong number of arguments '$#'." >&2; }
 
 set -f
 export LC_ALL=C
-___nl='
+_nl='
 '


### PR DESCRIPTION
Make mini versions compatible with scripts using the -u shell flag by
capturing unset variables.

This commit makes _check_vars accept empty parameters.

---

This patch aims to allow users to use `-u` flag in their script while calling the mini version.

I'm not sure how you are suppose to create the array in the mini version (also, the mini versions are not in the test scripts as far as i know), so i created a "bastard" version of the declare functions to test it.

Before this patch series:
```console
./posix-arrays-i-mini.sh: line 70: $2: unbound variable
./posix-arrays-a-mini.sh: line 69: $3: unbound variable
```

After this patch series:
```console
0 1 2 3 4 5 6 7 8
999
declare_i_arr: Error: invalid array name 'iarr_*'.
set_i_arr_el: Error: invalid array name 'iarr_*'.
foo woo
foo,bar
```

Here is the script i used to test it:

indexed array test
```sh
#!/bin/sh

set -u

. ./posix-arrays-i-mini.sh

declare_i_arr() {
	___me="declare_i_arr"
	case "$*" in '') wrongargs "$@"; return 1; esac
	_arr_name="$1"; shift
	_check_vars "$_arr_name" || return 1

	_index=0; _indices=''
	for ___val in "$@"; do
		_indices="$_indices$_nl$_index"
		_index=$((_index + 1))
	done
	_index=$((_index - 1))

	case "$_index" in
		"-1") ;;
		*) eval "_i_${_arr_name}_h_index"='$_index'"
				_i_${_arr_name}_indices"='$_indices'"
				_i_${_arr_name}_sorted_flag=1"
	esac
	:
}


declare_i_arr iarr 0 1 2 3 4 5 6 7 8
get_i_arr_indices iarr retval
echo $retval
set_i_arr_el iarr 4 999
get_i_arr_val iarr 4 retval
echo $retval

declare_i_arr iarr_* 0 0 1
if [ $? -ne 1 ]; then
	echo "expected failure"
fi
set_i_arr_el iarr_* 4 999
if [ $? -ne 1 ]; then
	echo "expected failure"
fi
```

associative test
```sh
#!/bin/sh

set -eu

. ./posix-arrays-a-mini.sh

check_pair() { case "$___pair" in *=* ) ;; *) echo "$___me: Error: '$___pair' is not a 'key=value' pair." >&2; return 1; esac; }

declare_a_arr() {
	___me="declare_a_arr"
	case "$*" in '') wrongargs "$@"; return 1; esac
	_arr_name="$1"; shift
	_out_var=""
	___keys=''
	_check_vars "$_arr_name" "$_out_var" || return 1

	case "$*" in *?* )
		for ___pair in "$@"; do
			check_pair || return 1
			___key="${___pair%%=*}"
			___val="${___pair#*=}"
			_check_vars "$___key" "$_out_var"  "$_arr_name" || return 1 # todo: revert assignments
			eval "_a_${_arr_name}_${___key}"='$___val'
			___keys="$___keys$_nl$___key"
		done
	esac

	eval "_a_${_arr_name}___keys=\"$___keys\"; _a_${_arr_name}_sorted_flag=0"

	:
}

declare_a_arr aarr foo="bar" woo="zee"
get_a_arr_keys aarr retval
echo $retval
set_a_arr_el aarr "foo=foo,bar" 
get_a_arr_val aarr foo retval
echo $retval
```

